### PR TITLE
Fixed broken link to Advanced Python: Functional Programming in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Resources and notes for the Zero to Mastery [Complete Python Developer course](h
 - Python Basics 2
 - Developer Environment
 - Advanced Python: Object-Oriented Programming
-- [Advanced Python: Functional Programming](https://github.com/zero-to-mastery/Complete-Python-Developer-Manuel/blob/main/functional_programming.ipynb)
+- [Advanced Python: Functional Programming](https://github.com/zero-to-mastery/Complete-Python-Developer-Manual/blob/main/Functional%20Programming.ipynb)
 - Advanced Python: Decorators
 - Advanced Python: Error Handling
 - Advanced Python: Generators


### PR DESCRIPTION
The link for Advanced Python: Functional Programming in the `README.md` has been updated so that it is no longer broken and instead links to the correct file: [Functional Programming.ipynb](https://github.com/zero-to-mastery/Complete-Python-Developer-Manual/blob/main/Functional%20Programming.ipynb)